### PR TITLE
Fix not getting all owned games

### DIFF
--- a/src/itchio.js
+++ b/src/itchio.js
@@ -1,6 +1,5 @@
 import fetch from "node-fetch";
 import fs from "fs";
-
 export async function login(username, password) {
   const params = new URLSearchParams();
   params.append("username", username);
@@ -18,13 +17,32 @@ export async function login(username, password) {
   return response.json();
 }
 
-export async function getGames(authorization) {
-  const response = await fetch("https://api.itch.io/profile/owned-keys", {
+async function getGamesPage(authorization, page) {
+  const response = await fetch(`https://api.itch.io/profile/owned-keys?page=${page}`, {
     headers: {
       authorization,
     },
   });
   return response.json();
+}
+
+export async function getGames(authorization) {
+  let result = [];
+  let loop = true;
+  let page = 1;
+  
+  while (loop) {
+    const { owned_keys: games } = await getGamesPage(authorization, page);
+    if (Array.isArray(games) && (games.length > 0)) { 
+      result = result.concat(games);
+    }
+    else
+    {
+      loop = false;
+    }
+    page++;
+  }
+  return result;
 }
 
 export async function getGameDownloads(game, authorization) {

--- a/src/sideload.js
+++ b/src/sideload.js
@@ -158,7 +158,7 @@ export async function sideload(message = console.log) {
   ]);
 
   message("[System]", "Processing libraries");
-  const [sideloads, { owned_keys: games }] = await Promise.all([
+  const [sideloads, games] = await Promise.all([
     getSideloads(),
     getGames(token),
   ]);


### PR DESCRIPTION
Hi,

The owned games api only returns 50 games at a time. I own over 1000 games and it was not finding all my playdate games because some of them were bought quite some time ago and they were not returned in the first 50 results.

I "tried" adding in a loop for getting all owned games from the api, while it seems to work for me, i'm not sure if i followed correct convetions related to nodejs and javascript as i usually don't program in those.

