### PR TITLE
fix href / url having changed on playdate site breaking sync again

### DIFF
--- a/src/playdate.js
+++ b/src/playdate.js
@@ -47,10 +47,14 @@ export async function getSideloads() {
 
   for (var i = 0; i < children.length; i++) {
     const child = children[i];
-    const url = "https://play.date" + child
-      .querySelector('a')
-      .getAttribute("href")
-
+    var url = child.querySelector('a').getAttribute("href");
+    //updated page starts with "//" and is missing https:
+    if (url.startsWith("//play.date"))
+      url = "https:" + url;
+    else
+      //old system href did not contain this
+      if(!url.startsWith("https://play.date"))
+        url = url + "https://play.date";
     const response2 = await fetch(url);
     const text2 = await response2.text();
     const dom2 = new JSDOM(text2);


### PR DESCRIPTION
href values for anchors linking to individual pages of playdate sideloaded games have changed. It used to use "accounts/.." but now they changed to ti "//play.date/" so i did a small adjustment for this just adding `https:` if thats the case. I also still left in the old change in case they have switch to that again