### PR TITLE
Add intelligent Playdate upload selection logic

### DIFF
--- a/src/itchio.js
+++ b/src/itchio.js
@@ -58,17 +58,42 @@ export async function getGameDownloads(game, authorization) {
   return response.json();
 }
 
+export function findPlaydateUpload(uploads) {
+  if (!uploads || uploads.length === 0) return null;
+  if (uploads.length === 1) return uploads[0];
+
+  // Prefer uploads with .pdx.zip extension
+  const pdxZip = uploads.find((u) =>
+    u.filename?.toLowerCase().endsWith(".pdx.zip")
+  );
+  if (pdxZip) return pdxZip;
+
+  // Look for "playdate" in the filename
+  const playdateInName = uploads.find((u) =>
+    u.filename?.toLowerCase().includes("playdate")
+  );
+  if (playdateInName) return playdateInName;
+
+  // Look for "playdate" in the display name
+  const playdateInDisplay = uploads.find((u) =>
+    u.display_name?.toLowerCase().includes("playdate")
+  );
+  if (playdateInDisplay) return playdateInDisplay;
+
+  // Fallback to first upload
+  return uploads[0];
+}
+
 export async function downloadGame(game, authorization) {
   const { game_id, id } = game;
-  const {
-    uploads: [upload],
-  } = await getGameDownloads(
+  const { uploads } = await getGameDownloads(
     {
       game_id,
       id,
     },
     authorization
   );
+  const upload = findPlaydateUpload(uploads);
   let response = await fetch(
     `https://api.itch.io/games/${game_id}/download-sessions`,
     {

--- a/src/itchio.js
+++ b/src/itchio.js
@@ -62,26 +62,28 @@ export function findPlaydateUpload(uploads) {
   if (!uploads || uploads.length === 0) return null;
   if (uploads.length === 1) return uploads[0];
 
+  // Filter out uploads explicitly tagged for other platforms (Android, Windows, etc.)
+  // Playdate isn't a recognized itch.io platform, so Playdate uploads have no platform flags set
+  const nonTagged = uploads.filter(
+    (u) => !u.p_android && !u.p_windows && !u.p_linux && !u.p_osx
+  );
+  const candidates = nonTagged.length > 0 ? nonTagged : uploads;
+
   // Prefer uploads with .pdx.zip extension
-  const pdxZip = uploads.find((u) =>
+  const pdxZip = candidates.find((u) =>
     u.filename?.toLowerCase().endsWith(".pdx.zip")
   );
   if (pdxZip) return pdxZip;
 
-  // Look for "playdate" in the filename
-  const playdateInName = uploads.find((u) =>
-    u.filename?.toLowerCase().includes("playdate")
+  // Look for "playdate" in the filename or display name
+  const playdateMatch = candidates.find(
+    (u) =>
+      u.filename?.toLowerCase().includes("playdate") ||
+      u.display_name?.toLowerCase().includes("playdate")
   );
-  if (playdateInName) return playdateInName;
+  if (playdateMatch) return playdateMatch;
 
-  // Look for "playdate" in the display name
-  const playdateInDisplay = uploads.find((u) =>
-    u.display_name?.toLowerCase().includes("playdate")
-  );
-  if (playdateInDisplay) return playdateInDisplay;
-
-  // Fallback to first upload
-  return uploads[0];
+  return candidates[0];
 }
 
 export async function downloadGame(game, authorization) {

--- a/src/itchio.js
+++ b/src/itchio.js
@@ -62,26 +62,27 @@ export function findPlaydateUpload(uploads) {
   if (!uploads || uploads.length === 0) return null;
   if (uploads.length === 1) return uploads[0];
 
-  // Filter out uploads explicitly tagged for other platforms (Android, Windows, etc.)
-  // Playdate isn't a recognized itch.io platform, so Playdate uploads have no platform flags set
-  const nonTagged = uploads.filter(
-    (u) => !u.p_android && !u.p_windows && !u.p_linux && !u.p_osx
-  );
-  const candidates = nonTagged.length > 0 ? nonTagged : uploads;
-
-  // Prefer uploads with .pdx.zip extension
-  const pdxZip = candidates.find((u) =>
+  // Match .pdx.zip first across all uploads so a Playdate build tagged with
+  // desktop platform flags (e.g. p_windows) is never excluded
+  const pdxZip = uploads.find((u) =>
     u.filename?.toLowerCase().endsWith(".pdx.zip")
   );
   if (pdxZip) return pdxZip;
 
-  // Look for "playdate" in the filename or display name
-  const playdateMatch = candidates.find(
+  // Then look for "playdate" in filename or display name across all uploads
+  const playdateMatch = uploads.find(
     (u) =>
       u.filename?.toLowerCase().includes("playdate") ||
       u.display_name?.toLowerCase().includes("playdate")
   );
   if (playdateMatch) return playdateMatch;
+
+  // Fall back to platform filtering: Playdate isn't a recognized itch.io platform,
+  // so Playdate uploads typically have no platform flags set
+  const nonTagged = uploads.filter(
+    (u) => !u.p_android && !u.p_windows && !u.p_linux && !u.p_osx
+  );
+  const candidates = nonTagged.length > 0 ? nonTagged : uploads;
 
   return candidates[0];
 }

--- a/src/sideload.js
+++ b/src/sideload.js
@@ -4,6 +4,7 @@ import {
   getGames,
   downloadGame,
   getGameDownloads,
+  findPlaydateUpload,
 } from "./itchio.js";
 import fetch from "node-fetch";
 import { JSDOM } from "jsdom";
@@ -206,9 +207,8 @@ export async function sideload(message = console.log) {
     await PromisePool.for(Array.from(sideloaded))
       .withConcurrency(6)
       .process(async (game) => {
-        const {
-          uploads: [download],
-        } = await getGameDownloads(game, token);
+        const { uploads } = await getGameDownloads(game, token);
+        const download = findPlaydateUpload(uploads);
         if (
           log[game.game_id] &&
           log[game.game_id].md5_hash !== download.md5_hash
@@ -230,9 +230,6 @@ export async function sideload(message = console.log) {
           stats.skipped++;
         } else {
           message("[Sideload]", game.game.title);
-          const {
-            uploads: [download],
-          } = await getGameDownloads(game, token);
           const filename = await downloadGame(game, token);
           try {
             await uploadGame(filename);
@@ -248,9 +245,8 @@ export async function sideload(message = console.log) {
   if (needsSideload.size > 0) {
     for (const game of needsSideload) {
       message("[Sideload]", game.game.title);
-      const {
-        uploads: [download],
-      } = await getGameDownloads(game, token);
+      const { uploads } = await getGameDownloads(game, token);
+      const download = findPlaydateUpload(uploads);
       const filename = await downloadGame(game, token);
       try {
         await uploadGame(filename);


### PR DESCRIPTION
## Summary
This PR introduces a new `findPlaydateUpload()` function to intelligently select the correct Playdate game upload from itch.io, replacing the previous assumption that the first upload is always the correct one.

## Key Changes
- **New function `findPlaydateUpload()`**: Implements smart upload selection with the following logic:
  - Filters out uploads explicitly tagged for other platforms (Android, Windows, Linux, macOS)
  - Prioritizes `.pdx.zip` files (the standard Playdate format)
  - Falls back to uploads with "playdate" in the filename or display name
  - Returns the first candidate if no specific match is found
  
- **Updated `downloadGame()`**: Now uses `findPlaydateUpload()` instead of blindly taking the first upload

- **Updated `sideload()`**: Refactored to use `findPlaydateUpload()` in three locations:
  - Upload hash comparison check
  - New sideload processing
  - Existing sideload processing
  - Removed redundant `getGameDownloads()` call in the new sideload path

## Implementation Details
The selection algorithm prioritizes uploads in this order:
1. Non-platform-tagged uploads (since Playdate isn't a recognized itch.io platform)
2. Falls back to all uploads if no untagged ones exist
3. Within candidates, prefers `.pdx.zip` extension
4. Then looks for "playdate" in filename or display name
5. Finally returns the first candidate as a fallback

This makes the sideload process more robust when games have multiple uploads on itch.io.

https://claude.ai/code/session_01JcqMtAsA5KALLzqpZbKFhm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the upload-selection logic used for downloads/sideloading; incorrect heuristics or missing uploads could cause the wrong file to be downloaded or runtime failures in the sync flow.
> 
> **Overview**
> **Improves itch.io download selection for Playdate builds** by introducing `findPlaydateUpload()` to choose an upload based on platform flags, `.pdx.zip` extension, and "playdate" name matches, with a fallback to the first candidate.
> 
> Updates `downloadGame()` and the sideload/update/skip logic in `sideload.js` to use this selector (and avoids an extra redundant `getGameDownloads()` call), so MD5 comparisons and downloads are performed against the intended Playdate artifact when games have multiple uploads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf082204de9d6547ab398eeeb94aecb84c785a93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->