### PR TITLE
Follow-up: add GitHub Actions release workflow and README updates for npm + GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release and publish package
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        run: |
+          cp package.json package.json.bak
+          OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          npm pkg set name="@${OWNER_LOWER}/playdate-itchio-sync"
+          npm pkg set publishConfig.registry="https://npm.pkg.github.com"
+          npm publish
+          mv package.json.bak package.json
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -6,8 +6,15 @@ Keep your Playdate sideload games synced with your itch.io playdate game library
 - [Bun](https://bun.sh) v1.0+
 
 ## Install
+
+From npm:
 ```
 bun install playdate-itchio-sync -g
+```
+
+From GitHub Packages:
+```
+npm install -g @<github-owner>/playdate-itchio-sync --registry=https://npm.pkg.github.com
 ```
 
 ## Directions
@@ -15,6 +22,22 @@ bun install playdate-itchio-sync -g
 2. Follow the prompts for your credentials, they will be saved locally.
 3. A sync will kick off.
 4. You are done! From now on, just run `syncpd`, your credentials are saved.
+
+
+## Release automation
+
+Releases and package publishing are automated through `.github/workflows/release.yml`:
+
+1. Create and push a version tag (for example `v3.1.0`).
+2. GitHub Actions will:
+   - install dependencies and run type checking
+   - publish `playdate-itchio-sync` to npm
+   - publish `@<github-owner>/playdate-itchio-sync` to GitHub Packages
+   - create a GitHub release with generated notes
+
+Repository secrets required:
+
+- `NPM_TOKEN`: npm automation token with publish permission
 
 ## Environment Variables
 


### PR DESCRIPTION
### Motivation
- Automate releases and package publishing for `playdate-itchio-sync` so tagged versions create npm and GitHub Packages artifacts and a GitHub Release.
- Provide clear install instructions and document the tag-driven release flow and required repository secrets.

### Description
- Added `.github/workflows/release.yml` which runs on `v*` tags and manual dispatch and performs checkout, sets up Bun and Node, installs deps, runs `bun run typecheck`, publishes `playdate-itchio-sync` to npm, publishes a scoped `@<owner>/playdate-itchio-sync` to GitHub Packages by temporarily modifying `package.json`, and creates a release with generated notes using `softprops/action-gh-release@v2`.
- Updated `README.md` to include installation instructions for both npm and GitHub Packages and a new "Release automation" section describing tagging, what the workflow does, and the `NPM_TOKEN` secret requirement.
- The GitHub Packages publish step scopes the package name dynamically to the repository owner at runtime.

### Testing
- Ran `bun run typecheck` in the environment which failed due to missing `bun-types` type definitions (test failed).
- Attempted `bun install` to validate dependency installation which failed with repeated `403` responses from the npm registry in this environment (test failed).
- Attempted to fetch GitHub Actions docs programmatically to validate configuration but the network request returned `403 Forbidden` in this environment (validation failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4bd9bde4832497eabc257d08c917)